### PR TITLE
Fix close error dispatching on incorrect queue

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -759,8 +759,10 @@ private class InnerWebSocket: Hashable {
                 }
             case .closeConn:
                 if let error = finalError {
-                    self.event.error(error)
-                    self.eventDelegate?.webSocketError(error as NSError)
+                    fire {
+                        self.event.error(error)
+                        self.eventDelegate?.webSocketError(error as NSError)
+                    }
                 }
                 privateReadyState = .closed
                 if rd != nil {


### PR DESCRIPTION
`self.event.error` was being dispatched on the websocket's queue, when it should be dispatched on the queue specified by the library user. Wrapping this in a `fire { }` call like other events resolves the issue by correctly using the specified queue.